### PR TITLE
Urgent, change temp file folder from "tmp" to mkdtemp

### DIFF
--- a/super-slomo/inference.py
+++ b/super-slomo/inference.py
@@ -15,11 +15,11 @@ from models.slomo_model import SloMoNet
 def extract_frames(video_path: pathlib.Path, output_path: pathlib.Path):
     """
     Extract frames from videos in the input folder.
-    :param video_path:
+    :param video_path: path to source video
     :param output_path:
     :return: the output filename and the size of the frames
     """
-    output_filename = tempfile.mkdtemp()
+    data_path = tempfile.mkdtemp()
     vidcap = cv2.VideoCapture(str(video_path))
 
     width = int(vidcap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -30,12 +30,12 @@ def extract_frames(video_path: pathlib.Path, output_path: pathlib.Path):
     while success:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         cv2.imwrite(
-            "{}/frame%04d.jpg".format(output_filename) % count, image
+            "{}/frame%04d.jpg".format(data_path) % count, image
         )  # save frame as JPEG file
         success, image = vidcap.read()
         count += 1
     vidcap.release()
-    return output_filename, width, height
+    return data_path, width, height
 
 
 def load_dataset(data_path: pathlib.Path, batch_size: int = 32):

--- a/super-slomo/inference.py
+++ b/super-slomo/inference.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import pathlib
 import shutil
+import tempfile
 
 import cv2
 import numpy as np
@@ -18,8 +19,7 @@ def extract_frames(video_path: pathlib.Path, output_path: pathlib.Path):
     :param output_path:
     :return: the output filename and the size of the frames
     """
-    output_filename = output_path.parent / "tmp"
-    pathlib.Path(output_filename).mkdir(parents=True, exist_ok=True)
+    output_filename = tempfile.mkdtemp()
     vidcap = cv2.VideoCapture(str(video_path))
 
     width = int(vidcap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -47,7 +47,7 @@ def load_dataset(data_path: pathlib.Path, batch_size: int = 32):
     """
     autotune = tf.data.experimental.AUTOTUNE
     ds = (
-        tf.data.Dataset.list_files(str(data_path / "*"), shuffle=False)
+        tf.data.Dataset.list_files(str(data_path) + "/frame*", shuffle=False)
         .window(2, 1, drop_remainder=True)
         .flat_map(lambda window: window.batch(2))
         .map(load_frames, num_parallel_calls=autotune)

--- a/super-slomo/inference.py
+++ b/super-slomo/inference.py
@@ -12,11 +12,10 @@ import dataset
 from models.slomo_model import SloMoNet
 
 
-def extract_frames(video_path: pathlib.Path, output_path: pathlib.Path):
+def extract_frames(video_path: pathlib.Path):
     """
     Extract frames from videos in the input folder.
     :param video_path: path to source video
-    :param output_path:
     :return: the output filename and the size of the frames
     """
     data_path = tempfile.mkdtemp()
@@ -103,7 +102,7 @@ def predict(
     :param fps_out: fps of the output video
     :return:
     """
-    data_path, w, h = extract_frames(video_path, output_path)
+    data_path, w, h = extract_frames(video_path)
 
     model = SloMoNet(n_frames=n_frames + 2)
     tf.train.Checkpoint(net=model).restore(str(model_path)).expect_partial()


### PR DESCRIPTION

Original code would potentially wipe out tmp -named directory on destination video's folder.

Luckily the inference crashed on unknown file formats and I didn't lose my .. stuff..